### PR TITLE
Add Snyk CI scans: code, os

### DIFF
--- a/.github/workflows/snyk-code-scan.yml
+++ b/.github/workflows/snyk-code-scan.yml
@@ -1,0 +1,17 @@
+name: Snyk Code Scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  snyk-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Snyk
+        uses: snyk/actions/setup@master
+      - name: Snyk Code Test
+        run: snyk code test --severity-threshold=high --org=my-org
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk-os-scan.yml
+++ b/.github/workflows/snyk-os-scan.yml
@@ -1,0 +1,21 @@
+name: Snyk Open Source Scan
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  snyk-os:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Snyk
+        uses: snyk/actions/setup@master
+      - name: Snyk Test
+        run: snyk test --severity-threshold=high --org=my-org
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Snyk Monitor
+        run: snyk monitor --org=my-org
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Snyk Pipeline Coverage Remediation

This PR adds CI pipeline configuration to satisfy the following policy rules:

- **Snyk Code Scan** (`snyk-code-scan-1`) — high
- **Snyk Open Source Scans** (`snyk-os-scan-1`) — high
- **Snyk OS Scan Sarif** (`snyk-os-scan-sarif`) — high

### Files added

- `.github/workflows/snyk-code-scan.yml`
- `.github/workflows/snyk-os-scan.yml`

---
*Generated by [snyk-pipeline-coverage](https://github.com/snyk-labs/snyk-pipeline-coverage)*